### PR TITLE
docs: update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# The Toolkit Book
-
-# Introduction
+---
+# metadata up here
+---
 
 The Solana Toolkit consists of all open sourced tools for smart contract development on the Solana Blockchain.
 
@@ -8,7 +8,7 @@ You can contribute to this book on [GitHub]().
 
 ## Installation
 
-To get started, install The Solana Toolkit.
+To get started, install The Solana toolkit:
 
 ```shell
 npx solana install
@@ -16,11 +16,11 @@ npx solana install
 
 This will install the latest versions of the following:
 
-- [Solana CLI/ Agave Tool Suite](https://docs.solanalabs.com/cli/): A command line tool that allows developers to interact with the Solana blockchain, manage accounts, send transactions, and deploy programs.
+- [Solana CLI / Agave Tool Suite](https://docs.anza.xyz/cli/): A command line tool that allows developers to interact with the Solana blockchain, manage accounts, send transactions, and deploy programs.
 - [Rust](https://doc.rust-lang.org/book/): The Programming language that Solana Smart Contracts are written in.
-- [Anchor](https://www.anchor-lang.com/): A framework for writing solana programs that abstracts many complexities to speed up smart contract development.
-- [Trident](): A fuzz tester
-- [Zest](): A code coverage tool
+- [Anchor](https://www.anchor-lang.com/): A framework for writing Solana programs that abstracts many complexities to speed up smart contract development.
+- [Trident](https://ackee.xyz/trident/docs/latest/): A fuzz tester
+- [Zest](https://github.com/LimeChain/zest?tab=readme-ov-file): A code coverage tool
 
 ## Getting Started
 
@@ -28,19 +28,17 @@ This section will cover all the toolkit basics to help you get started.
 
 ### Keypair generation
 
-For a fresh installation of the [Solana CLI](https://docs.solanalabs.com/cli/), you're required to generate a new keypair.
+For a fresh installation of the [Solana CLI](https://docs.anza.xyz/cli/), you're required to generate a new keypair. 
 
 ```shell
 solana-keygen new
 ```
 
-Set the keypair path:
-
-```shell
-solana config set --keypair <path_to_keypair>
-```
-
-Check the pubkey of your machines newly generated keypair:
+The above command will both:
+- print the pubkey generated
+- store the your new keypair at the Solana CLI's default path (`~/.config/solana/id.json`) unless you already have a keypair saved there
+ 
+Check the pubkey of your machine's newly generated keypair: 
 
 ```shell
 solana address
@@ -76,13 +74,17 @@ To log the network run:
 solana logs
 ```
 
-For a more information, read the [Solana Test Validator Guide](https://solana.com/developers/guides/getstarted/solana-test-validator).
+For a more information, read this [Solana Test Validator Guide](https://solana.com/developers/guides/getstarted/solana-test-validator).
 
-# Projects
+## Projects
 
-## Creating a New Project
+### Creating a New Project
 
-To start a new project with the solana toolkit, pick a which scaffold you want to use. There are scaffolds for stand alone smart contract workspaces, web app workspaces, or mobile app workspaces.
+To start a new project with the Solana toolkit, pick which scaffold you want to use. There are scaffolds for:
+- [Anchor framework workspaces](#anchor-smart-contract-scaffold)
+- [general scaffolds using `create-solana-program`](#general-smart-contract-scaffold)
+- [web app workspaces](#web-app-scaffold)
+- [mobile app workspaces](#mobile-app-templates)
 
 ### Anchor Smart Contract Scaffold
 
@@ -100,9 +102,9 @@ This initializes a simplistic workspace set up for Anchor smart contract develop
 - `tests/`: Directory for JavaScript integration tests.
 - `migrations/deploy.js`: Deploy script.
 
-The anchor framework abstracts away many complexities enabling fast program development.
+The Anchor framework abstracts away many complexities enabling fast program development.
 
-For more information on the anchor framework, check out the [anchor book](https://www.anchor-lang.com/).
+For more information on the Anchor framework, check out the [Anchor book](https://www.anchor-lang.com/).
 
 To test out this project before making any modifications, just build and test:
 
@@ -122,23 +124,19 @@ npx create-solana-program
 
 This initializes a more complex workspace with everything you need for general Solana smart contract development.
 
-This command gives you the option to choose between Shank and Anchor for the program framework.
+This command gives you the option to choose between Shank and Anchor for the program framework:
 
-- **Shank** creates a vanilla Solana smart contract with Shank macros to generate IDLs
+- **Shank** creates a vanilla Solana smart contract with Shank macros to generate IDLs. For more information on Shank, check out its [README](https://github.com/metaplex-foundation/shank).
 
-For more information on Shank, check out the [README](https://github.com/metaplex-foundation/shank).
+- **Anchor** creates a smart contract using the Anchor framework, which abstracts away many complexities enabling fast program development. For more information on the Anchor framework, check out the [Anchor book](https://www.anchor-lang.com/).
 
-- **Anchor** creates a smart contract using the anchor framework, which abstracts away many complexities enabling fast program development.
+This command also gives the option to choose between a JavaScript client, a Rust Client, or both.
 
-For more information on the anchor framework, check out the [anchor book](https://www.anchor-lang.com/).
-
-This command also gives the option to choose between a JS client, a Rust Client, or both.
-
-- **JavaScript Client** creates a typescript library compatible with web3.js.
+- **JavaScript Client** creates a typescript library compatible with [web3.js](https://solana-labs.github.io/solana-web3.js/).
 
 - **Rust Client** creates a rust crate allowing consumers to interact with the smart contract.
 
-For further workspace customization and additional information, check out the [README](https://github.com/solana-program/create-solana-program/tree/main).
+For further workspace customization and additional information, check out the `create-solana-program` [README](https://github.com/solana-program/create-solana-program/tree/main).
 
 ### Web App Scaffold
 
@@ -146,46 +144,46 @@ For further workspace customization and additional information, check out the [R
 npx create-solana-dapp
 ```
 
-This command generates a new project that connects a solana smart contract to a front end with a wallet connector.
+This command generates a new project that connects a Solana smart contract to a frontend with a wallet connector.
 
-For additional information, check out the [README](https://github.com/solana-developers/create-solana-dapp).
+For additional information, check out its [README](https://github.com/solana-developers/create-solana-dapp).
 
-To test out this project before making any modifications, follow these steps.
+To test out this project before making any modifications, follow these steps:
 
-Build the smart contract:
+1. Build the smart contract:
 
 ```shell
 npm run anchor-build
 ```
 
-Start the local validator:
+2. Start the local validator:
 
 ```shell
 npm run anchor-localnet
 ```
 
-Run tests:
+3. Run tests:
 
 ```shell
 npm run anchor-test
 ```
 
-Deploy to the local validator:
+4. Deploy to the local validator:
 
 ```shell
 npm run anchor deploy --provider.cluster localnet
 ```
 
-Build Web App:
+5. Build the web app:
 
 ```shell
-pnpm build
+npm run build
 ```
 
-Run Web App:
+6. Run the web app:
 
 ```shell
-pnpm dev
+npm run dev
 ```
 
 ### Mobile App Templates
@@ -196,9 +194,9 @@ yarn create expo-app --template @solana-mobile/solana-mobile-expo-template
 
 This is initializing a new project using the Expo framework that is specifically designed for creating mobile applications that interact with the Solana blockchain.
 
-Follow the [Running the app](https://docs.solanamobile.com/react-native/expo#running-the-app) guide to launch the template as a custom development build and get it running on your Android emulator. Once you have built the program and are running a dev client with expo, the emulator will automatically update every time you save your code.
+Follow their [Running the app](https://docs.solanamobile.com/react-native/expo#running-the-app) guide to launch the template as a custom development build and get it running on your Android emulator. Once you have built the program and are running a dev client with Expo, the emulator will automatically update every time you save your code.
 
-To use this, you will also need to set up the following:
+To use this template, you will also need to set up the following:
 
 - [Android Studio and Emulator](https://docs.solanamobile.com/getting-started/development-setup)
 - [React Native](https://reactnative.dev/docs/environment-setup?platform=android)
@@ -208,7 +206,7 @@ For additional information on Solana Mobile Development: https://docs.solanamobi
 
 ## Smart Contract Layout
 
-Typically Solana smart contract workspaces will be have the following file structure:
+Typically Solana smart contract (aka [programs](/docs/core/programs.md)) workspaces will be have the following file structure:
 
 ```shell
 .
@@ -252,43 +250,42 @@ As the smart contract gets more cumbersome, you'll typically want to separate th
 
 ## Working on an Existing Project
 
-The Solana Tool Kit makes developing with existing projects have no overhead.
+The Solana toolkit makes developing with existing projects have no overhead.
 
 ```shell
 npm install
 ```
 
 ```shell
-solana build
+npx solana build
 ```
 
 ```shell
-solana test
+npx solana test
 ```
 
 ```shell
-solana deploy --provider.cluster <localnet || devnet || mainnet || testnet>
+npx solana deploy
 ```
 
 ## Verifiable Programs
 
 ## Dependencies??
 
-# Solana Test Suite Overview
+## Solana Test Suite Overview
 
-Within the toolkit, there are several resources for testing Solana Smart Contracts, including:
+Within the Solana toolkit, there are several resources for testing Solana Smart Contracts, including:
 
-- A fuzzer
+- Zest - A fuzzer
 - A code coverage tool
-- A step debugger????
 - A framework for testing Solana programs in NodeJS that spins up a lightweight `BanksServer` that's like an RPC node but much faster and creates a `BanksClient` to talk to the server.
 - A fast and lightweight library for testing Solana programs in Rust, which works by creating an in-process Solana VM optimized for program developers.
 - A tool to scan your repo for common security vulnerabilities and provide suggestions for fixes.
 - A reference guide of important cheat codes to simplify writing tests.
 
-## Testing Basics
+### Testing Basics
 
-Sync all the program's key, if you're using an anchor program:
+Sync all the program's key. If you're using an Anchor program:
 
 ```shell
 anchor keys sync
@@ -297,22 +294,22 @@ anchor keys sync
 Build the smart contract:
 
 ```shell
-solana build
+npx solana build
 ```
 
 Test the smart contract:
 
 ```shell
-solana test
+npx solana test
 ```
 
 Deploy the smart contract:
 
 ```shell
-solana deploy --provider.cluster <localnet || devnet || testnet || mainnet>
+npx solana deploy
 ```
 
-If deploying to mainnet, you must first start your local validator:
+If deploying to localnet, you must first start your local validator:
 
 ```shell
 solana-test-validator
@@ -320,12 +317,12 @@ solana-test-validator
 
 For more information on local validator customization and commands, read the [Solana Test Validator Guide](https://solana.com/developers/guides/getstarted/solana-test-validator).
 
-## Fuzz Tester
+### Fuzz Tester
 
 Generate fuzz tests:
 
 ```shell
-solana fuzz
+npx solana fuzz
 ```
 
 This command will initialize a Trident workspace and generate a new Fuzz Test Template:
@@ -348,7 +345,7 @@ project-root
 Run fuzz tests:
 
 ```shell
-solan fuzz run
+npx solana fuzz run
 ```
 
 The output of the fuzz tests is as follows:
@@ -375,29 +372,27 @@ The output of the fuzz tests is as follows:
 
 View the source code [here](https://github.com/Ackee-Blockchain/trident).
 
-## Code Coverage Tool
+### Code Coverage Tool
 
 ```shell
-solana coverage
+npx solana coverage
 ```
 
 This command will run a code coverage test on all of your Rust tests and then generate report in an HTML page with in depth metrics on where additional code may be needed to improve your current code coverage.
 
-Note: So far, this tool only works on tests written in Rust and is not compatible with a JS test suite.
+Note: So far, this tool only works on tests written in Rust and is not compatible with a JavaScript test suite.
 
 View the source code [here](https://github.com/LimeChain/zest?tab=readme-ov-file).
 
-## Step Debugger
+### JavaScript Testing Framework
 
-## JS testing Framework
+### Rust Testing Library
 
-## Rust Testing Library
-
-## Security Vulnerability Scanner
+### Security Vulnerability Scanner
 
 ## Solana Cheat Codes
 
-Most of the time, simply testing your smart contracts outputs isn’t enough. To manipulate the state of the blockchain, as well as test for specific reverts and events, you can use the
+Most of the time, simply testing your smart contract's outputs isn’t enough. To manipulate the state of the blockchain, as well as test for specific reverts and events, you can use the
 
 ```Rust
 // Example Rust function to adjust account balances in a test environment
@@ -420,7 +415,9 @@ fn adjust_account_balance(account: &AccountInfo, amount: u64) -> Result<(), Prog
 
 The Solana test validator is a local emulator for the Solana blockchain, designed to provide developers with a private and controlled environment for building and testing Solana programs without the need to connect to a public testnet or mainnet. If you have the Solana CLI tool suite already installed, you can run the test validator with the following command:
 
+```shell
 solana-test-validator
+```
 
 Advantages #
 
@@ -435,13 +432,19 @@ Advantages #
 - Configurable epoch length
 - Installation #
 
-Since the solana-test-validator is part of the Solana CLI tool suite, ensure you have Solana's command-line tools installed. You can install them using the following command:
+Since the `solana-test-validator` is part of the Solana CLI tool suite, ensure you have Solana's command-line tools installed. You can install the entire Solana toolkit (which includes the Solana CLI) using the following command:
+
+```shell
+npx solana install
+```
+
+Or install just the Solana CLI with:
 
 ```shell
 sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
 ```
 
-You can replace stable with the release tag matching the software version of your desired release (i.e. v1.18.12), or use one of the three symbolic channel names: stable, beta, or edge.
+You can replace `stable` with the release tag matching the software version of your desired release (i.e. `v1.18.12`), or use one of the three symbolic channel names: `stable`, `beta`, or `edge`.
 
 ### Starting the Test Validator
 
@@ -455,7 +458,20 @@ This command initializes a new ledger and starts the validator.
 
 ### Interacting with a Running Test Validator
 
-Once you have the solana-test-validator up and running, you can interact with it using various Solana CLI (Command Line Interface) commands. These commands let you deploy programs, manage accounts, send transactions, and much more. Here's a detailed guide on the key commands you will use.
+Once you have the `solana-test-validator` up and running, you can interact with it using various Solana CLI commands. These commands let you deploy programs, manage accounts, send transactions, and much more. Here's a detailed guide on the key commands you will use.
+
+
+Check your current CLI configuration to see which network you are selected too:
+
+```shell
+solana config get
+```
+
+If needed update your Solana configuration to connect to your test validator running on localhost:
+
+```shell
+solana config set --url localhost
+```
 
 ### Checking the Status of the Test Validator
 
@@ -469,29 +485,37 @@ This command pings the local test validator and returns the current blockhash an
 
 ### Account Management
 
-To create a new keypair (account), use:
+View the pubkey of your configured CLI keypair:
 
 ```shell
-solana-keygen new
+solana address
 ```
 
-This command creates a new keypair and saves it to the specified file.
-
-To add SOL to your account:
+View the current balance of your keypair:
 
 ```shell
-solana airdrop 10 <ACCOUNT_ADDRESS>
+solana balance
 ```
 
-To retrieve details about an account, such as its balance and owner:
+To add SOL to your CLI keypair, request an airdrop:
+
+```shell
+solana airdrop 10
+```
+
+To retrieve details about any account, such as its balance and owner:
 
 ```shell
 solana account <ACCOUNT_ADDRESS>
 ```
 
-You must first airdrop funds to the account for the account to exist.
+You must first add SOL to an account for it to exist. This airdrop command requests 2 SOL to the specified account address:
 
-This command sends 10 SOL to the specified account address.
+```shell
+solana airdrop 2 <ACCOUNT_ADDRESS>
+```
+
+Aside from "wallet accounts" that only hold SOL, accounts are normally created by smart contracts (aka programs) so they can store the `data` desired by that program.
 
 ### Deploying and Managing Programs
 
@@ -517,11 +541,11 @@ To transfer SOL from one account to another:
 solana transfer --from /path/to/keypair.json <RECIPIENT_ADDRESS> <AMOUNT>
 ```
 
-This sends AMOUNT of SOL from the source account to the RECIPIENT_ADDRESS.
+This sends `AMOUNT` of SOL from the source account to the `RECIPIENT_ADDRESS`.
 
 ### Simulating and Confirming Transactions
 
-Before actually sending a transaction, you can simulate it to see if it would succeed:
+Before actually sending a transaction, you can simulate it to see if it would likely succeed:
 
 ```shell
 solana transfer --from /path/to/keypair.json --simulate <RECIPIENT_ADDRESS> <AMOUNT>
@@ -553,11 +577,11 @@ solana logs
 
 This streams log messages from the validator.
 
-### Useful Tips Logging:
+### Tips for Logging
 
-Increase log verbosity with the -v flag if you need more detailed output for debugging.
-Use the --rpc-port and --rpc-bind-address options to customize the RPC server settings.
-Adjust the number of CPU cores used by the validator with the --gossip-host option to simulate network conditions more realistically.
+- Increase log verbosity with the `-v` flag if you need more detailed output for debugging.
+- Use the `--rpc-port` and `--rpc-bind-address` options to customize the RPC server settings.
+- Adjust the number of CPU cores used by the validator with the `--gossip-host` option to simulate network conditions more realistically.
 
 ### Configuration
 
@@ -575,11 +599,11 @@ solana-test-validator --help
 
 ### Local Ledger
 
-By default, the ledger data is stored in a directory named test-ledger in your current working directory.
+By default, the ledger data is stored in a directory named `test-ledger` in your current working directory.
 
 ### Specifying Ledger Location
 
-When starting the test validator, you can specify a different directory for the ledger data using the --ledger option:
+When starting the test validator, you can specify a different directory for the ledger data using the `--ledger` option:
 
 ```shell
 solana-test-validator --ledger /path/to/custom/ledger
@@ -587,83 +611,116 @@ solana-test-validator --ledger /path/to/custom/ledger
 
 ### Resetting the Ledger
 
-By default the validator will resume an existing ledger. To reset the ledger, you can either manually delete the ledger directory or restart the validator with the --reset flag:
+By default the validator will resume an existing ledger, if one is found. To reset the ledger, you can either manually delete the ledger directory or restart the validator with the `--reset` flag:
 
+```shell
 solana-test-validator --reset
+```
 
-If the ledger exists, this command will reset the ledger to genesis, which resets the state by deleting all existing data and starting fresh.
+If the ledger exists, this command will reset the ledger to genesis, which resets the state by deleting all existing accounts and starting fresh.
 
-Runtime Features #
-Solana has a feature set mechanism that allows you to enable or disable certain blockchain features when running the test validator. By default, the test validator runs with all runtime features activated.
+### Cloning Programs
 
-To query the runtime feature status:
+To add existing onchain programs to your local environment, you can clone the program with a new ledger. This is useful for testing interactions with other programs that already exist on any other cluster.
 
-solana feature status <ADDRESS>
+To clone an account from another cluster:
 
-ADDRESS is the feature status to query [default: all known features]
-To activate a specific feature:
-
-solana feature activate <FEATURE_KEYPAIR> <CLUSTER>
-
-FEATURE_KEYPAIR is the signer for the feature to activate
-CLUSTER is the cluster to activate the feature on
-To deactivate specific features in genesis:
-
-solana-test-validator --deactivate-feature <FEATURE_PUBKEY> --reset
-
-This must be done on a fresh ledger, so if a ledger already exists in your working directory you must add the --reset flag to reset to genesis.
-
-Changing Versions #
-To check your current solana-test-validator version:
-
-solana-test-validator --version
-
-Your solana-test-validator runs on the same version as the Solana CLI version.
-
-To test your programs against different versions of the Solana runtime, you can install multiple versions of the Solana CLI and switch between them using the solana-install set command:
-
-solana-install init <VERSION>
-
-VERSION is the desired CLI version to install
-Make sure to restart your Solana test validator after changing versions to ensure it runs the correct version.
-
-Cloning Programs #
-To add existing onchain programs to your local environment, you can clone the program with a new ledger.
-
-To clone an account from the cluster:
-
+```shell
 solana-test-validator --clone PROGRAM_ADDRESS --url CLUSTER_PROGRAM_IS_DEPLOYED_TO
+```
 
-This is useful for testing interactions with standard programs.
+To clone an upgradeable program and its executable data from another cluster:
 
-If a ledger already exists in your working directory, you must reset the ledger to be able to clone a program.
+```shell
+solana-test-validator --clone-upgradeable-program PROGRAM_ADDRESS --url CLUSTER_PROGRAM_IS_DEPLOYED_TO
+```
+
+> If a ledger already exists in your working directory, you must reset the ledger to be able to clone a program.
+
+### Cloning Accounts
+
+To add existing onchain accounts to your local environment, you can clone the account with a new ledger from any other network cluster.
 
 To clone an account from the cluster when a ledger already exists:
 
-solana-test-validator --clone PROGRAM_ADDRESS --url CLUSTER_PROGRAM_IS_DEPLOYED_TO --reset
+```shell
+solana-test-validator --clone ACCOUNT_ADDRESS --url CLUSTER_PROGRAM_IS_DEPLOYED_TO --reset
+```
 
-To clone an upgradeable program and its executable data from the cluster:
+### Reset to Specific Account Data
 
-solana-test-validator --clone-upgradeable-program PROGRAM_ADDRESS --url CLUSTER_PROGRAM_IS_DEPLOYED_TO
-
-Resetting State on Accounts at Startup #
-By default the validator will resume an existing ledger (if present). But during startup, you can reset the ledger either to genesis or to specific account state that you provide.
-
-Reset to Genesis #
-To reset the ledger to the genesis state:
-
-solana-test-validator --reset
-
-Reset to Specific Accounts #
-To reset the state of specific accounts every time you start the validator, you can use a combination of account snapshots and the --account flag.
+To reset the state of specific accounts every time you start the validator, you can use a combination of account snapshots and the `--account` flag.
 
 First, save the desired state of an account as a JSON file:
 
-solana account PROGRAM_ADDRESS --output json > account_state.json
+```shell
+solana account ACCOUNT_ADDRESS --output json > account_state.json
+```
 
 Then load this state each time you reset the validator:
 
-solana-test-validator --reset --account PROGRAM_ADDRESS account_state.json
+```shell
+solana-test-validator --reset --account ACCOUNT_ADDRESS account_state.json
+```
+
+### Runtime Features
+
+Solana has a feature set mechanism that allows you to enable or disable certain blockchain features when running the test validator. By default, the test validator runs with all runtime features activated.
+
+To see all the runtime features available and their statuses:
+
+```shell
+solana feature status
+```
+
+To query a specific runtime feature's status:
+
+```shell
+solana feature status <ADDRESS>
+```
+
+To activate a specific feature:
+
+```shell
+solana feature activate <FEATURE_KEYPAIR> <CLUSTER>
+```
+
+- `FEATURE_KEYPAIR` is the signer for the feature to activate
+- `CLUSTER` is the cluster to activate the feature on
+
+To deactivate specific features in genesis:
+
+```shell
+solana-test-validator --deactivate-feature <FEATURE_PUBKEY> --reset
+```
+
+This must be done on a fresh ledger, so if a ledger already exists in your working directory you must add the `--reset` flag to reset to genesis.
+
+### Changing Versions
+
+To check your current `solana-test-validator` version:
+
+```shell
+solana-test-validator --version
+```
+
+Your test validator runs on the same version as the Solana CLI installed and configured for use.
+
+To test your programs against different versions of the Solana runtime, you can install multiple versions of the Solana CLI and switch between them using the following command:
+
+```shell
+solana-install init <VERSION>
+```
+
+Make sure to reset your Solana test validator's ledger after changing versions to ensure it runs a valid ledger without corruption.
+
+## Solana.toml file configs
+
+## Compute and Fees Section
+
+you dont need to track gas but you can optimize compute.
+
+// link to jonas's compute docs -> advanced section
 
 Solana CLI Commands #
 To view all CLI commands and see other ways to interact with the test validator:
@@ -682,11 +739,3 @@ Create a token account
 spl-token create-account EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --url localhost
 
 // FIXME: Add in how to connect to test validator from the front end
-
-## Solana.toml file configs
-
-## Compute and Fees Section
-
-you dont need to track gas but you can optimize compute.
-
-// link to jonas's compute docs -> advanced section


### PR DESCRIPTION
# general

- should we use `npx solana test-validator` instead of `solana-test-validator`?
- the solana node cli does not have the following commands (which are used in the doc):
  - `test`
  - `fuzz` and `fuzz run`
- removed mentions of the step debugger since it does not exist yet (I dont think)
- "Here's a detailed guide on the key commands you will use."
  - where is this supposed to link to?

---

specific sections:

## Working on an Existing Project

- do we need to add any more info in here around these commands?
- the solana node cli does not have a `test` command (ie `npx solana test`)
    - i recommend we remove this test line from this now

## Verifiable Programs

- i think we remove this section for now since that cli and api are having issues. cut scope now and add it back in later
- i plan to add more direct node cli support for the verify cli, but have not gotten to it yet. maybe when that is added we add this section in?

## Dependencies??
- currently blank. do we need this?

### JavaScript Testing Framework
- currently blank. do we need this?

### Rust Testing Library
- currently blank. do we need this?
### Security Vulnerability Scanner
- currently blank. do we need this?
### Creating Token Accounts
- currently blank. do we need this?
## Solana.toml file configs
- currently blank. lets remove this?

## Solana Cheat Codes
- is this section ready to go live?
- does the listed function actually work?